### PR TITLE
스플래시 화면 추가

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:theme="@style/Theme.Akuma"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".SplashActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -21,5 +21,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"/>
     </application>
+
 </manifest>

--- a/presentation/src/main/java/com/whiplash/presentation/SplashActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/SplashActivity.kt
@@ -1,0 +1,34 @@
+package com.whiplash.presentation
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.lifecycleScope
+import com.whiplash.presentation.databinding.ActivitySplashBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class SplashActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivitySplashBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        binding = ActivitySplashBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
+        lifecycleScope.launch {
+            delay(1000)
+        }
+    }
+}

--- a/presentation/src/main/java/com/whiplash/presentation/SplashActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/SplashActivity.kt
@@ -7,6 +7,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
 import com.whiplash.presentation.databinding.ActivitySplashBinding
+import com.whiplash.presentation.util.ActivityUtils.navigateTo
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -29,6 +30,9 @@ class SplashActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             delay(1000)
+            navigateTo<MainActivity> {
+                finishCurrentActivity()
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/whiplash/presentation/util/ActivityUtils.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/util/ActivityUtils.kt
@@ -1,0 +1,136 @@
+package com.whiplash.presentation.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Parcelable
+
+/**
+ * 액티비티 이동 관련 유틸 함수 관리
+ */
+object ActivityUtils {
+
+    /**
+     * 액티비티 이동 함수
+     *
+     * @param intentExtras putExtra()에 담을 데이터를 가진 map
+     * @param intentFlags 인텐트 플래그. 여러 플래그 사용 시 or 연산으로 조합해야 함
+     * @param hasFinishCurrentActivity 현재 액티비티에서 finish() 호출 여부
+     */
+    inline fun <reified T : Activity> Context.navigateTo(
+        intentExtras: Map<String, Any>? = null,
+        intentFlags: Int? = null,
+        hasFinishCurrentActivity: Boolean = false
+    ) {
+        val intent = Intent(this, T::class.java).apply {
+            intentFlags?.let { flags = it }
+            intentExtras?.forEach { (key, value) ->
+                when (value) {
+                    is String -> putExtra(key, value)
+                    is Int -> putExtra(key, value)
+                    is Long -> putExtra(key, value)
+                    is Float -> putExtra(key, value)
+                    is Double -> putExtra(key, value)
+                    is Boolean -> putExtra(key, value)
+                    is ByteArray -> putExtra(key, value)
+                    is Parcelable -> putExtra(key, value)
+                    else -> throw IllegalArgumentException("지원하지 않는 extra type : ${value::class.java}")
+                }
+            }
+        }
+
+        startActivity(intent)
+
+        if (hasFinishCurrentActivity && this is Activity) {
+            finish()
+        }
+    }
+
+    /**
+     * DSL 스타일의 액티비티 이동 함수
+     *
+     * 사용 예시
+     *
+     * ```kotlin
+     * context.navigateTo<MainActivity> {
+     *     putExtra("id", "test")
+     *     putExtra("name", "user")
+     *     // 둘 이상의 인텐트 플래그 사용 시 or 연산 필수
+     *     setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+     *     finishCurrentActivity()
+     * }
+     * ```
+     *
+     * @see NavigationBuilder
+     */
+    inline fun <reified T : Activity> Context.navigateTo(
+        builder: NavigationBuilder<T>.() -> Unit
+    ) = NavigationBuilder(this, T::class.java).apply(builder).navigate()
+
+    /**
+     * 액티비티 이동을 DSL 형태로 처리하는 빌더 클래스
+     *
+     * @param T 이동할 액티비티의 타입
+     * @param context 현재 컨텍스트
+     * @param destination 이동할 액티비티
+     */
+    class NavigationBuilder<T: Activity>(
+        private val context: Context,
+        private val destination: Class<T>,
+    ) {
+        private val intentExtras = mutableMapOf<String, Any>()
+        private var intentFlags: Int? = null
+        private var hasFinishCurrentActivity: Boolean = false
+
+        fun putExtra(key: String, value: Any) {
+            intentExtras[key] = value
+        }
+
+        /**
+         * 기존 인텐트 플래그에 매개변수 플래그를 덮어씌움
+         *
+         * @param flags 해당 인텐트에 새로 설정할 플래그
+         */
+        fun setFlags(flags: Int) {
+            intentFlags = flags
+        }
+
+        /**
+         * 기존 인텐트 플래그 외의 새 인텐트 플래그 추가
+         *
+         * @param flags 해당 인텐트에 새로 추가할 플래그
+         */
+        fun addFlags(flags: Int) {
+            intentFlags = (intentFlags ?: 0) or flags
+        }
+
+        fun finishCurrentActivity() {
+            this.hasFinishCurrentActivity = true
+        }
+
+        fun navigate() {
+            val intent = Intent(context, destination).apply {
+                intentFlags?.let { flags = it }
+                intentExtras.forEach { (key, value) ->
+                    when (value) {
+                        is String -> putExtra(key, value)
+                        is Int -> putExtra(key, value)
+                        is Long -> putExtra(key, value)
+                        is Float -> putExtra(key, value)
+                        is Double -> putExtra(key, value)
+                        is Boolean -> putExtra(key, value)
+                        is ByteArray -> putExtra(key, value)
+                        is Parcelable -> putExtra(key, value)
+                        else -> throw IllegalArgumentException("지원하지 않는 extra type : ${value::class.java}")
+                    }
+                }
+            }
+
+            context.startActivity(intent)
+
+            if (hasFinishCurrentActivity && context is Activity) {
+                context.finish()
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/whiplash/presentation/util/ActivityUtils.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/util/ActivityUtils.kt
@@ -13,6 +13,19 @@ object ActivityUtils {
     /**
      * 액티비티 이동 함수
      *
+     * 사용 예시:
+     * ```kotlin
+     * // 이동만 처리
+     * context.navigateTo<MainActivity>()
+     *
+     * // 값 추가해서 이동
+     * context.navigateTo<MainActivity>(
+     *     intentExtras = mapOf("userId" to 123, "userName" to "홍길동"),
+     *     intentFlags = Intent.FLAG_ACTIVITY_CLEAR_TOP,
+     *     hasFinishCurrentActivity = true
+     * )
+     * ```
+     *
      * @param intentExtras putExtra()에 담을 데이터를 가진 map
      * @param intentFlags 인텐트 플래그. 여러 플래그 사용 시 or 연산으로 조합해야 함
      * @param hasFinishCurrentActivity 현재 액티비티에서 finish() 호출 여부

--- a/presentation/src/main/res/layout/activity_splash.xml
+++ b/presentation/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".SplashActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/activity_splash.xml
+++ b/presentation/src/main/res/layout/activity_splash.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/main"
+    android:id="@+id/splash_main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".SplashActivity">


### PR DESCRIPTION
## 📝 변경 사항
- 스플래시 화면 추가 및 1초 후 메인 액티비티 이동 처리(디자인, 이동 시간은 추후 수정)
- 액티비티 화면 이동 함수 추가

> 액티비티 화면 이동 로직에 왜 inline, reified를 썼는가?

인텐트를 통한 화면 전환 시 같이 넘길 값이 있으면 putExtra, 플래그를 설정해야 하면 add/setFlags를 사용하고
이전 화면을 제거해야 하면 finish()를 호출했는데 이 과정을 하나의 함수에 담아서 처리하면 화면 이동 로직 처리가 더 보기 편해질 것 같았다

그래서 액티비티 이동 관련 유틸 함수를 만들고 람다 블록 안에서 putExtra, add/setFlags 등의 함수를 호출할 수 있게 DSL 형태로 작성했다
처음 사용한 DSL이라 오류가 발생할 수 있어 개발하면서 발견되는 대로 수정할 예정. 메인 액티비티 이동 시에는 오류 발생하지 않았음

제네릭에 이동할 목적지 액티비티를 명시하는데, 코틀린에선 런타임에 제네릭 타입 정보가 타입 소거(Type Erasure)로 인해 사라지는 문제가 있다
이를 해결하기 위해 inline fun, reified를 써서 런타임에도 타입 정보를 유지할 수 있게 했다
제네릭 타입 인자를 사용할 때 오버헤드를 줄이기 위해서 inline fun을 사용했지만 오버헤드가 얼마나 줄어들지는 확인 필요

## 🎯 작업 유형
- [x] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일 변경 (style)
- [ ] 문서 변경 (docs)
- [ ] 프로젝트 설정 변경 (chore)
- [ ] 기타