### PR TITLE
refactor: 카카오 로그아웃 시 unlink 대신 logout 함수 호출하게 수정

### DIFF
--- a/data/src/main/kotlin/com/whiplash/data/repository/login/KakaoAuthRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/whiplash/data/repository/login/KakaoAuthRepositoryImpl.kt
@@ -35,14 +35,14 @@ class KakaoAuthRepositoryImpl @Inject constructor(
             suspendCancellableCoroutine { continuation ->
                 // logout 사용 시 재로그인하면 팝업이 표시되지 않음
                 // unlink를 써야 로그아웃 후 재로그인 시 팝업 표시됨
-                UserApiClient.instance.unlink { error ->
+                UserApiClient.instance.logout { error ->
                     if (error != null) {
-                        Timber.e("## [카카오 레포 impl] 카카오 연결 해제 실패 : $error")
+                        Timber.e("## [카카오 레포 impl] 카카오 로그아웃 실패 : $error")
                         // 토큰이 이미 만료된 경우에도 로컬 토큰 삭제
                         TokenManagerProvider.instance.manager.clear()
                         continuation.resume(Unit)
                     } else {
-                        Timber.d("## [카카오 레포 impl] 카카오 연결 해제 성공")
+                        Timber.d("## [카카오 레포 impl] 카카오 로그아웃 성공")
                         TokenManagerProvider.instance.manager.clear()
                         continuation.resume(Unit)
                     }


### PR DESCRIPTION
## 📝 변경 사항
- 카카오 로그아웃 시 unlink 대신 logout 호출하게 수정

unlink로 로그아웃하면 재로그인 시 팝업이 표시되고 logout으로 로그아웃하면 재로그인 시 팝업이 표시되지 않는다
기획 상 logout을 호출하는 플로우를 사용하는 것으로 확인되어 카카오 로그아웃 로직 수정

## 🎯 작업 유형
- [ ] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일 변경 (style)
- [ ] 문서 변경 (docs)
- [ ] 프로젝트 설정 변경 (chore)
- [ ] 기타