### PR TITLE
refactor: 홈 화면 상단의 팝업에서 x 제거 및 관련 기능 제거

### DIFF
--- a/presentation/src/main/java/com/whiplash/presentation/dialog/AlarmAlertPopup.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/dialog/AlarmAlertPopup.kt
@@ -3,7 +3,6 @@ package com.whiplash.presentation.dialog
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.View
 import android.widget.FrameLayout
 import com.whiplash.presentation.databinding.LayoutHomeAlertPopupBinding
 
@@ -14,14 +13,6 @@ class AlarmAlertPopup @JvmOverloads constructor(
 ) : FrameLayout(context, attrs, defStyleAttr) {
 
     private val binding = LayoutHomeAlertPopupBinding.inflate(LayoutInflater.from(context), this, true)
-
-    init {
-        with(binding) {
-            ivCloseHomeAlertPopup.setOnClickListener {
-                visibility = View.GONE
-            }
-        }
-    }
 
     fun setAlertTexts(
         firstText: String,

--- a/presentation/src/main/res/layout/layout_home_alert_popup.xml
+++ b/presentation/src/main/res/layout/layout_home_alert_popup.xml
@@ -56,14 +56,6 @@
             app:layout_constraintTop_toTopOf="@+id/ivSecondAlert"
             tools:text="‘알람 끄기’는 알람별로 3회까지 가능해요!" />
 
-        <ImageView
-            android:id="@+id/ivCloseHomeAlertPopup"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:src="@drawable/ic_circle_dismiss_22"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 📝 변경 사항
- 홈 화면 상단의 알람 팝업 내부 오른쪽 위에 있던 x 아이콘 제거
- 해당 아이콘에 포함돼 있던 뷰 gone 처리 로직 제거

정보를 계속 표시하기 위한 텍스트라면 계속 띄워두는 게 맞다는 의견이 있어 관련 UI, 로직 제거함

## 🎯 작업 유형
- [ ] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일 변경 (style)
- [ ] 문서 변경 (docs)
- [ ] 프로젝트 설정 변경 (chore)
- [ ] 기타

## 📱 스크린샷 (UI 변경 시)
<img width="340" height="720" alt="image" src="https://github.com/user-attachments/assets/4072db0e-ec37-4097-925e-8348ef148c22" />