### PR TITLE
feat: 홈 화면에 메뉴 아이콘 추가

### DIFF
--- a/presentation/src/main/java/com/whiplash/presentation/main/MainActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/main/MainActivity.kt
@@ -55,6 +55,9 @@ class MainActivity : AppCompatActivity() {
             ivAddAlarm.setOnClickListener {
                 navigateTo<CreateAlarmActivity>{}
             }
+
+            ivDotMenu.setOnClickListener {
+            }
         }
 
         mainViewModel.getAlarms()

--- a/presentation/src/main/java/com/whiplash/presentation/main/MainActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/main/MainActivity.kt
@@ -1,7 +1,11 @@
 package com.whiplash.presentation.main
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
+import android.widget.PopupWindow
+import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -57,6 +61,7 @@ class MainActivity : AppCompatActivity() {
             }
 
             ivDotMenu.setOnClickListener {
+                showThreeDotMenu()
             }
         }
 
@@ -98,4 +103,48 @@ class MainActivity : AppCompatActivity() {
             secondText = getString(R.string.home_alert_second_text),
         )
     }
+
+    private fun showThreeDotMenu() {
+        val popupView = LayoutInflater.from(this).inflate(R.layout.menu_home_popup, null)
+        val popupWindow = PopupWindow(
+            popupView,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            true
+        )
+
+        // popupWindow는 뷰 바인딩 대상이 아니라 findViewById()로 내부 뷰에 접근
+        val tvRemoveAlarm = popupView.findViewById<TextView>(R.id.tvRemoveAlarm)
+        val tvManageUserInfo = popupView.findViewById<TextView>(R.id.tvManageUserInfo)
+
+        tvRemoveAlarm.setOnClickListener {
+            popupWindow.dismiss()
+            Timber.d("## [팝업] 알람 삭제 클릭")
+        }
+
+        tvManageUserInfo.setOnClickListener {
+            popupWindow.dismiss()
+            Timber.d("## [팝업] 회원 정보 관리 클릭")
+        }
+
+        // 화면의 전체 width 조회
+        val screenWidth = resources.displayMetrics.widthPixels
+        popupView.measure(
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        )
+        val popupWidth = popupView.measuredWidth
+
+        // 화면에서 ivDotMenu의 위치
+        val location = IntArray(2)
+        binding.ivDotMenu.getLocationOnScreen(location)
+        val anchorLeft = location[0]
+
+        // xOffset을 계산해서 오른쪽에서 20dp 떨어진 곳에 popupWindow 표시
+        val xOffset =
+            screenWidth - (anchorLeft + popupWidth) - (20 * resources.displayMetrics.density).toInt()
+
+        popupWindow.showAsDropDown(binding.ivDotMenu, xOffset, 0)
+    }
+
 }

--- a/presentation/src/main/res/drawable/bg_home_popup.xml
+++ b/presentation/src/main/res/drawable/bg_home_popup.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/grey_800" />
+    <corners android:radius="8dp" />
+</shape>

--- a/presentation/src/main/res/layout/activity_main.xml
+++ b/presentation/src/main/res/layout/activity_main.xml
@@ -33,8 +33,18 @@
         android:id="@+id/ivAddAlarm"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="18dp"
+        android:layout_marginEnd="8dp"
         android:src="@drawable/ic_plus_28"
+        app:layout_constraintBottom_toBottomOf="@+id/tvHomeAlarmList"
+        app:layout_constraintEnd_toStartOf="@+id/ivDotMenu"
+        app:layout_constraintTop_toTopOf="@+id/tvHomeAlarmList" />
+
+    <ImageView
+        android:id="@+id/ivDotMenu"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="18dp"
+        android:src="@drawable/ic_dot_28"
         app:layout_constraintBottom_toBottomOf="@+id/tvHomeAlarmList"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/tvHomeAlarmList" />

--- a/presentation/src/main/res/layout/menu_home_popup.xml
+++ b/presentation/src/main/res/layout/menu_home_popup.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_home_popup"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/tvRemoveAlarm"
+        style="@style/body2_m_14"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/remove_alarm"
+        android:textColor="@color/grey_300" />
+
+    <TextView
+        android:id="@+id/tvManageUserInfo"
+        style="@style/body2_m_14"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="22dp"
+        android:layout_marginBottom="6dp"
+        android:text="@string/manage_user_info"
+        android:textColor="@color/grey_300" />
+
+</LinearLayout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="ok_string">확인</string>
     <string name="cancel_string">취소</string>
     <string name="disable_alarm">알람 끄기</string>
+    <string name="remove_alarm">알람 삭제</string>
+    <string name="manage_user_info">회원 정보 관리</string>
 
     <string name="time_am">오전</string>
     <string name="time_pm">오후</string>


### PR DESCRIPTION
## 📝 변경 사항
- 홈 화면 + 아이콘 오른쪽에 점 3개 아이콘 추가
- 점 3개 아이콘 클릭 시 PopupWindow 표시 처리 추가 + PopupWindow용 커스텀 UI 구현
- 화면 width를 구해서 화면 오른쪽으로부터 20dp 떨어진 곳에 PopupWindow 표시되게 구현 (폴드 에뮬, 일반 기기에서 확인)
- PopupWindow 내부 텍스트뷰에 클릭 리스너 추가 및 PopupWindow dismiss 함수 호출 처리 추가

## 🎯 작업 유형
- [x] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일 변경 (style)
- [ ] 문서 변경 (docs)
- [ ] 프로젝트 설정 변경 (chore)
- [ ] 기타

## 📱 스크린샷 (UI 변경 시)
<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/bcbaacd4-79a1-4ab8-9e21-715c8f500206" />
