### PR TITLE
refactor: 네이버 지도 다크모드 적용

### DIFF
--- a/presentation/src/main/java/com/whiplash/presentation/map/SelectPlaceActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/map/SelectPlaceActivity.kt
@@ -114,6 +114,8 @@ class SelectPlaceActivity : AppCompatActivity(), OnMapReadyCallback {
     override fun onMapReady(map: NaverMap) {
         naverMap = map
         naverMap.apply {
+            isNightModeEnabled = true
+            mapType = NaverMap.MapType.Navi // Navi 유형만 다크모드를 지원해서 Navi 타입으로 설정해야 함
             locationSource = locationSource
             uiSettings.isLocationButtonEnabled = true
         }


### PR DESCRIPTION
## 📝 변경 사항
- 장소 설정 화면에서 쓰는 네이버 지도를 다크모드로 표시되게 수정

디자이너 분의 요청으로 네이버 지도를 다크모드로 표시하게 수정하게 변경
다크모드는 Navi 모드일 때만 적용 가능해서 mapType을 반드시 Navi로 설정해야 함

ref
- https://www.ncloud-forums.com/topic/136/
- https://navermaps.github.io/android-map-sdk/guide-ko/2-3.html (야간 모드 항목)

## 🎯 작업 유형
- [ ] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일 변경 (style)
- [ ] 문서 변경 (docs)
- [ ] 프로젝트 설정 변경 (chore)
- [ ] 기타

## 📱 스크린샷 (UI 변경 시)
<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/a63be1b7-f3b6-49d5-bf77-80d30d756a23" />