### PR TITLE
project: 레트로핏 기본 설정 추가 및 토큰 재발급 api 테스트 구현

### DIFF
--- a/data/src/main/kotlin/com/whiplash/data/datastore/TokenDataStore.kt
+++ b/data/src/main/kotlin/com/whiplash/data/datastore/TokenDataStore.kt
@@ -19,6 +19,7 @@ class TokenDataStore @Inject constructor(
     companion object {
         private val KEY_ACCESS_TOKEN = stringPreferencesKey("access_token")
         private val KEY_REFRESH_TOKEN = stringPreferencesKey("refresh_token")
+        private val KEY_DEVICE_ID = stringPreferencesKey("device_id")
     }
 
     val accessToken: Flow<String?> = context.dataStore.data
@@ -27,10 +28,19 @@ class TokenDataStore @Inject constructor(
     val refreshToken: Flow<String?> = context.dataStore.data
         .map { it[KEY_REFRESH_TOKEN] }
 
+    val deviceId: Flow<String?> = context.dataStore.data
+        .map { it[KEY_DEVICE_ID] }
+
     suspend fun saveTokens(accessToken: String, refreshToken: String) {
         context.dataStore.edit { prefs ->
             prefs[KEY_ACCESS_TOKEN] = accessToken
             prefs[KEY_REFRESH_TOKEN] = refreshToken
+        }
+    }
+
+    suspend fun saveDeviceId(deviceId: String) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_DEVICE_ID] = deviceId
         }
     }
 

--- a/data/src/main/kotlin/com/whiplash/data/di/ProviderModule.kt
+++ b/data/src/main/kotlin/com/whiplash/data/di/ProviderModule.kt
@@ -1,0 +1,19 @@
+package com.whiplash.data.di
+
+import com.whiplash.data.provider.TokenProviderImpl
+import com.whiplash.domain.provider.TokenProvider
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ProviderModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTokenProvider(impl: TokenProviderImpl): TokenProvider
+
+}

--- a/data/src/main/kotlin/com/whiplash/data/mapper/AlarmMapper.kt
+++ b/data/src/main/kotlin/com/whiplash/data/mapper/AlarmMapper.kt
@@ -1,7 +1,7 @@
 package com.whiplash.data.mapper
 
 import com.whiplash.domain.entity.GetAlarmEntity
-import com.whiplash.network.dto.AlarmDto
+import com.whiplash.network.dto.response.AlarmDto
 
 fun AlarmDto.toEntity(): GetAlarmEntity = GetAlarmEntity(
     alarmId = alarmId,

--- a/data/src/main/kotlin/com/whiplash/data/provider/TokenProviderImpl.kt
+++ b/data/src/main/kotlin/com/whiplash/data/provider/TokenProviderImpl.kt
@@ -1,0 +1,31 @@
+package com.whiplash.data.provider
+
+import com.whiplash.data.datastore.TokenDataStore
+import com.whiplash.domain.provider.TokenProvider
+import kotlinx.coroutines.flow.Flow
+import timber.log.Timber
+import javax.inject.Inject
+
+class TokenProviderImpl @Inject constructor(
+    private val tokenDataStore: TokenDataStore
+): TokenProvider {
+
+    override val accessToken: Flow<String?> = tokenDataStore.accessToken
+    override val refreshToken: Flow<String?> = tokenDataStore.refreshToken
+    override val deviceId: Flow<String?> = tokenDataStore.deviceId
+
+    override suspend fun saveTokens(accessToken: String, refreshToken: String) {
+        Timber.d("## [data] 데이터 모듈에서 saveTokens() 호출. accessToken: $accessToken, refreshToken: $refreshToken")
+        tokenDataStore.saveTokens(accessToken, refreshToken)
+    }
+
+    override suspend fun saveDeviceId(deviceId: String) {
+        Timber.d("## [data] 데이터 모듈에서 saveDeviceId() 호출. deviceId: $deviceId")
+        tokenDataStore.saveDeviceId(deviceId)
+    }
+
+    override suspend fun clearTokens() {
+        Timber.d("## [data] 데이터 모듈에서 clearTokens() 호출")
+        tokenDataStore.clearTokens()
+    }
+}

--- a/domain/src/main/java/com/whiplash/domain/provider/TokenProvider.kt
+++ b/domain/src/main/java/com/whiplash/domain/provider/TokenProvider.kt
@@ -1,0 +1,12 @@
+package com.whiplash.domain.provider
+
+import kotlinx.coroutines.flow.Flow
+
+interface TokenProvider {
+    val accessToken: Flow<String?>
+    val refreshToken: Flow<String?>
+    val deviceId: Flow<String?>
+    suspend fun saveTokens(accessToken: String, refreshToken: String)
+    suspend fun saveDeviceId(deviceId: String)
+    suspend fun clearTokens()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ coroutines-core = "1.7.3"
 okhttp = "4.12.0"
 okhttpUrlconnection = "4.9.2"
 retrofit = "3.0.0"
+kotlinxSerialization = "1.0.0"
 timber = "5.0.1"
 jetbrainsKotlinJvm = "2.0.21"
 
@@ -70,6 +71,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
 converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
+converter-kotlinx-serialization = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "kotlinxSerialization" }
 
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
 
     implementation(libs.retrofit)
-    implementation(libs.converter.gson)
+    implementation(libs.converter.kotlinx.serialization)
     implementation(libs.okhttp)
     implementation(libs.logging.interceptor)
     implementation(libs.hilt)

--- a/network/src/main/kotlin/com/whiplash/network/api/AlarmService.kt
+++ b/network/src/main/kotlin/com/whiplash/network/api/AlarmService.kt
@@ -1,6 +1,6 @@
 package com.whiplash.network.api
 
-import com.whiplash.network.dto.ResponseGetAlarmList
+import com.whiplash.network.dto.response.ResponseGetAlarmList
 import retrofit2.http.GET
 
 interface AlarmService {

--- a/network/src/main/kotlin/com/whiplash/network/api/AuthService.kt
+++ b/network/src/main/kotlin/com/whiplash/network/api/AuthService.kt
@@ -1,0 +1,21 @@
+package com.whiplash.network.api
+
+import com.whiplash.network.dto.request.RequestTokenReissue
+import com.whiplash.network.dto.response.ResponseReissueToken
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthService {
+
+    /**
+     * 토큰 재발급
+     *
+     * @return accessToken, refreshToken
+     */
+    @POST("auth/reissue")
+    suspend fun reissueToken(
+        @Body requestTokenReissue: RequestTokenReissue
+    ): Response<ResponseReissueToken>
+
+}

--- a/network/src/main/kotlin/com/whiplash/network/authenticator/TokenAuthenticator.kt
+++ b/network/src/main/kotlin/com/whiplash/network/authenticator/TokenAuthenticator.kt
@@ -1,0 +1,59 @@
+package com.whiplash.network.authenticator
+
+import com.whiplash.domain.provider.TokenProvider
+import com.whiplash.network.api.AuthService
+import com.whiplash.network.dto.request.RequestTokenReissue
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import javax.inject.Inject
+
+/**
+ * 토큰 재발급 담당
+ */
+class TokenAuthenticator @Inject constructor(
+    private val tokenProvider: TokenProvider,
+    private val authService: AuthService
+) : Authenticator {
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        // 토큰 재발급 API는 재발급 로직에서 제외
+        if (response.request.url.encodedPath.contains("auth/reissue")) {
+            return null
+        }
+
+        val deviceId = runBlocking {
+            tokenProvider.deviceId.firstOrNull()
+        } ?: return null
+
+        return try {
+            val reissueResponse = runBlocking {
+                authService.reissueToken(RequestTokenReissue(deviceId))
+            }
+
+            if (reissueResponse.isSuccessful && reissueResponse.body()?.isSuccess == true) {
+                val tokenResult = reissueResponse.body()!!.result
+
+                runBlocking {
+                    tokenProvider.saveTokens(
+                        tokenResult.accessToken,
+                        tokenResult.refreshToken
+                    )
+                }
+
+                response.request.newBuilder()
+                    .header("Authorization", "Bearer ${tokenResult.accessToken}")
+                    .build()
+            } else {
+                runBlocking { tokenProvider.clearTokens() }
+                null
+            }
+        } catch (e: Exception) {
+            runBlocking { tokenProvider.clearTokens() }
+            null
+        }
+    }
+}

--- a/network/src/main/kotlin/com/whiplash/network/di/RetrofitModule.kt
+++ b/network/src/main/kotlin/com/whiplash/network/di/RetrofitModule.kt
@@ -1,0 +1,80 @@
+package com.whiplash.network.di
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.whiplash.domain.provider.TokenProvider
+import com.whiplash.network.api.AuthService
+import com.whiplash.network.authenticator.TokenAuthenticator
+import com.whiplash.network.interceptor.AuthInterceptor
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideJson(): Json {
+        return Json {
+            ignoreUnknownKeys = true // data class에 정의하지 않은 값을 받으면 무시
+            coerceInputValues = true // null인 경우 기본값 설정
+            prettyPrint = true
+        }
+    }
+
+    @Provides
+    @Singleton
+    fun provideAuthInterceptor(tokenProvider: TokenProvider): AuthInterceptor =
+        AuthInterceptor(tokenProvider)
+
+    @Provides
+    @Singleton
+    fun provideTokenAuthenticator(
+        tokenProvider: TokenProvider,
+        authService: AuthService
+    ): TokenAuthenticator = TokenAuthenticator(tokenProvider, authService)
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(
+        authInterceptor: AuthInterceptor,
+        tokenAuthenticator: TokenAuthenticator
+    ): OkHttpClient {
+        val loggingInterceptor = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
+        return OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .addInterceptor(authInterceptor)
+            .authenticator(tokenAuthenticator)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(okHttpClient: OkHttpClient, json: Json): Retrofit =
+        Retrofit.Builder()
+            .baseUrl("http://3.34.221.212:8080/api/")
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideAuthService(retrofit: Retrofit): AuthService =
+        retrofit.create(AuthService::class.java)
+}

--- a/network/src/main/kotlin/com/whiplash/network/dto/request/RequestTokenReissue.kt
+++ b/network/src/main/kotlin/com/whiplash/network/dto/request/RequestTokenReissue.kt
@@ -1,0 +1,8 @@
+package com.whiplash.network.dto.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestTokenReissue(
+    val deviceId: String,
+)

--- a/network/src/main/kotlin/com/whiplash/network/dto/response/ResponseGetAlarmList.kt
+++ b/network/src/main/kotlin/com/whiplash/network/dto/response/ResponseGetAlarmList.kt
@@ -1,4 +1,4 @@
-package com.whiplash.network.dto
+package com.whiplash.network.dto.response
 
 import kotlinx.serialization.Serializable
 

--- a/network/src/main/kotlin/com/whiplash/network/dto/response/ResponseReissueToken.kt
+++ b/network/src/main/kotlin/com/whiplash/network/dto/response/ResponseReissueToken.kt
@@ -1,0 +1,17 @@
+package com.whiplash.network.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseReissueToken(
+    val isSuccess: Boolean,
+    val code: String,
+    val message: String,
+    val result: TokenResult
+)
+
+@Serializable
+data class TokenResult(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/network/src/main/kotlin/com/whiplash/network/interceptor/AuthInterceptor.kt
+++ b/network/src/main/kotlin/com/whiplash/network/interceptor/AuthInterceptor.kt
@@ -1,0 +1,34 @@
+package com.whiplash.network.interceptor
+
+import com.whiplash.domain.provider.TokenProvider
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+/**
+ * api 요청 시 헤더에 bearer token 추가 담당
+ */
+class AuthInterceptor @Inject constructor(
+    private val tokenProvider: TokenProvider
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+
+        val accessToken = runBlocking {
+            tokenProvider.accessToken.firstOrNull()
+        }
+
+        val request = if (accessToken != null) {
+            originalRequest.newBuilder()
+                .addHeader("Authorization", "Bearer $accessToken")
+                .build()
+        } else {
+            originalRequest
+        }
+
+        return chain.proceed(request)
+    }
+}


### PR DESCRIPTION
## 📝 변경 사항
- network 모듈에 레트로핏 기본 설정 추가
- 헤더 추가, 토큰 재발급 담당 로직을 Interceptor, Authenticator를 상속한 각 클래스로 나눠서 처리하게 구현
- 토큰 재발급 api 테스트 구현
- dataStore에 deviceId 관련 저장, 조회 로직 추가

기본 설정만 추가했기 때문에 실제 api 통신 로직 구현하면서 오류 발생 시 수정 필요
gson 대신 kotlinx.serialization을 사용하기 위해 관련 설정 추가. 첫 사용이라 마찬가지로 오류 발생 시 수정 필요

## 🎯 작업 유형
- [x] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일 변경 (style)
- [ ] 문서 변경 (docs)
- [x] 프로젝트 설정 변경 (chore)
- [ ] 기타