### PR TITLE
feat: 문의하기 클릭 시 특정 이메일로 메일 전송

### DIFF
--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import com.whiplash.presentation.login.KakaoLoginManager
+import com.whiplash.presentation.util.WhiplashToast
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -95,6 +96,7 @@ class UserInfoActivity : AppCompatActivity() {
                 showRightArrow(true)
                 setOnItemClickListener {
                     Timber.d("## [회원정보] 문의하기 클릭")
+                    sendInquiryMail()
                 }
             }
 
@@ -122,6 +124,19 @@ class UserInfoActivity : AppCompatActivity() {
                     Timber.d("## [회원정보] 회원탈퇴 클릭")
                 }
             }
+        }
+    }
+
+    private fun sendInquiryMail() {
+        val emailIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "message/rfc822"
+            putExtra(Intent.EXTRA_EMAIL, arrayOf("hyg100@naver.com"))
+        }
+
+        try {
+            startActivity(Intent.createChooser(emailIntent, "문의하기"))
+        } catch (e: Exception) {
+            WhiplashToast.showErrorToast(this, "이메일 앱을 찾을 수 없습니다")
         }
     }
 


### PR DESCRIPTION
## 📝 변경 사항
- 회원 정보 화면에서 문의하기 클릭 시 메일 앱 선택하는 바텀 시트 표시 후 지메일 앱을 통해 특정 메일로 이메일 전송하는 기능 구현

## 🎯 작업 유형
- [x] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일 변경 (style)
- [ ] 문서 변경 (docs)
- [ ] 프로젝트 설정 변경 (chore)
- [ ] 기타