### PR TITLE
refactor: 회원 정보 화면 수정, 팝업 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <!-- 위치 권한 -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
@@ -11,6 +12,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
+        android:usesCleartextTraffic="true"
         android:name=".App"
         android:networkSecurityConfig="@xml/network_security_config"
         android:allowBackup="true"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 

--- a/presentation/src/main/java/com/whiplash/presentation/component/button/WhiplashCommonButton.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/component/button/WhiplashCommonButton.kt
@@ -32,6 +32,20 @@ class WhiplashCommonButton @JvmOverloads constructor(
                     setBackgroundColor(backgroundColor)
                 }
 
+                // 테두리 설정
+                val borderColor = getColor(R.styleable.WhiplashCommonButton_borderColor, 0)
+                val borderWidth = getDimensionPixelSize(R.styleable.WhiplashCommonButton_borderWidth, 0)
+
+                if (backgroundColor != 0) {
+                    if (borderColor != 0 && borderWidth > 0) {
+                        setBackgroundWithBorder(backgroundColor, borderColor, borderWidth)
+                    } else {
+                        setBackgroundColor(backgroundColor)
+                    }
+                } else if (borderColor != 0 && borderWidth > 0) {
+                    setBackgroundWithBorder(0, borderColor, borderWidth)
+                }
+
                 // 텍스트 설정
                 val text = getString(R.styleable.WhiplashCommonButton_buttonText)
                 text?.let { setText(it) }
@@ -54,6 +68,21 @@ class WhiplashCommonButton @JvmOverloads constructor(
         val drawable = GradientDrawable().apply {
             setColor(color)
             cornerRadius = 4f * context.resources.displayMetrics.density
+        }
+
+        binding.btnWhiplash.background = drawable
+    }
+
+    private fun setBackgroundWithBorder(backgroundColor: Int, borderColor: Int, borderWidth: Int) {
+        val drawable = GradientDrawable().apply {
+            if (backgroundColor != 0) {
+                setColor(backgroundColor)
+            }
+            cornerRadius = 4f * context.resources.displayMetrics.density
+
+            if (borderColor != 0 && borderWidth > 0) {
+                setStroke(borderWidth, borderColor)
+            }
         }
 
         binding.btnWhiplash.background = drawable

--- a/presentation/src/main/java/com/whiplash/presentation/di/DialogModule.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/di/DialogModule.kt
@@ -3,6 +3,7 @@ package com.whiplash.presentation.di
 import android.content.Context
 import com.whiplash.presentation.dialog.DisableAlarmPopup
 import com.whiplash.presentation.dialog.LogoutPopup
+import com.whiplash.presentation.dialog.WithdrawalPopup
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,5 +24,10 @@ object DialogModule {
     @ActivityScoped
     fun provideLogoutPopup(@ActivityContext context: Context): LogoutPopup =
         LogoutPopup(context)
+
+    @Provides
+    @ActivityScoped
+    fun provideWithdrawalPopup(@ActivityContext context: Context): WithdrawalPopup =
+        WithdrawalPopup(context)
 
 }

--- a/presentation/src/main/java/com/whiplash/presentation/di/DialogModule.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/di/DialogModule.kt
@@ -2,6 +2,7 @@ package com.whiplash.presentation.di
 
 import android.content.Context
 import com.whiplash.presentation.dialog.DisableAlarmPopup
+import com.whiplash.presentation.dialog.LogoutPopup
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,5 +18,10 @@ object DialogModule {
     @ActivityScoped
     fun provideDisableAlarmPopup(@ActivityContext context: Context): DisableAlarmPopup =
         DisableAlarmPopup(context)
+
+    @Provides
+    @ActivityScoped
+    fun provideLogoutPopup(@ActivityContext context: Context): LogoutPopup =
+        LogoutPopup(context)
 
 }

--- a/presentation/src/main/java/com/whiplash/presentation/dialog/LogoutPopup.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/dialog/LogoutPopup.kt
@@ -1,0 +1,84 @@
+package com.whiplash.presentation.dialog
+
+import android.app.Dialog
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.Window
+import android.view.WindowManager
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.whiplash.presentation.R
+import com.whiplash.presentation.databinding.LayoutLogoutPopupBinding
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+/**
+ * 회원 정보 화면에서 로그아웃 클릭 시 표시되는 팝업
+ */
+class LogoutPopup @Inject constructor(
+    @ApplicationContext private val context: Context
+): DefaultLifecycleObserver {
+
+    private val dialog = Dialog(context).apply {
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
+        setContentView(R.layout.layout_logout_popup)
+        setCanceledOnTouchOutside(false)
+    }
+
+    init {
+        // android.view.WindowLeaked 에러가 발생하지 않게 액티비티 컨텍스트인 경우 생명주기 옵저버로 등록
+        if (context is LifecycleOwner) {
+            context.lifecycle.addObserver(this)
+        }
+    }
+
+    fun show(logoutClickListener: () -> Unit) {
+        val binding = LayoutLogoutPopupBinding.inflate(LayoutInflater.from(context))
+
+        dialog.apply {
+            setContentView(binding.root)
+            window?.let {
+                it.decorView.setBackgroundResource(android.R.color.transparent)
+                it.setLayout(
+                    WindowManager.LayoutParams.MATCH_PARENT,
+                    WindowManager.LayoutParams.WRAP_CONTENT
+                )
+            }
+
+            with(binding) {
+                btnCancelLogout.setOnClickListener {
+                    dismiss()
+                }
+
+                btnLogout.setOnClickListener {
+                    logoutClickListener()
+                    dismiss()
+                }
+            }
+        }
+
+        dialog.show()
+    }
+
+    fun dismiss() {
+        if (dialog.isShowing) {
+            dialog.dismiss()
+        }
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+        if (dialog.isShowing) {
+            dialog.dismiss()
+        }
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        if (dialog.isShowing) {
+            dialog.dismiss()
+        }
+
+        // 생명주기 옵저버가 알아서 처리하지만 명시적으로 처리하게 해서 예외상황 방지
+        owner.lifecycle.removeObserver(this)
+    }
+
+}

--- a/presentation/src/main/java/com/whiplash/presentation/dialog/WithdrawalPopup.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/dialog/WithdrawalPopup.kt
@@ -1,0 +1,81 @@
+package com.whiplash.presentation.dialog
+
+import android.app.Dialog
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.Window
+import android.view.WindowManager
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.whiplash.presentation.R
+import com.whiplash.presentation.databinding.LayoutWithdrawalPopupBinding
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class WithdrawalPopup @Inject constructor(
+    @ApplicationContext private val context: Context
+): DefaultLifecycleObserver {
+
+    private val dialog = Dialog(context).apply {
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
+        setContentView(R.layout.layout_withdrawal_popup)
+        setCanceledOnTouchOutside(false)
+    }
+
+    init {
+        // android.view.WindowLeaked 에러가 발생하지 않게 액티비티 컨텍스트인 경우 생명주기 옵저버로 등록
+        if (context is LifecycleOwner) {
+            context.lifecycle.addObserver(this)
+        }
+    }
+
+    fun show(withdrawalClickListener: () -> Unit) {
+        val binding = LayoutWithdrawalPopupBinding.inflate(LayoutInflater.from(context))
+
+        dialog.apply {
+            setContentView(binding.root)
+            window?.let {
+                it.decorView.setBackgroundResource(android.R.color.transparent)
+                it.setLayout(
+                    WindowManager.LayoutParams.MATCH_PARENT,
+                    WindowManager.LayoutParams.WRAP_CONTENT
+                )
+            }
+
+            with(binding) {
+                btnCancelWithdrawal.setOnClickListener {
+                    dismiss()
+                }
+
+                btnWithdrawal.setOnClickListener {
+                    withdrawalClickListener()
+                    dismiss()
+                }
+            }
+        }
+
+        dialog.show()
+    }
+
+    fun dismiss() {
+        if (dialog.isShowing) {
+            dialog.dismiss()
+        }
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+        if (dialog.isShowing) {
+            dialog.dismiss()
+        }
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        if (dialog.isShowing) {
+            dialog.dismiss()
+        }
+
+        // 생명주기 옵저버가 알아서 처리하지만 명시적으로 처리하게 해서 예외상황 방지
+        owner.lifecycle.removeObserver(this)
+    }
+
+}

--- a/presentation/src/main/java/com/whiplash/presentation/main/MainActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/main/MainActivity.kt
@@ -136,7 +136,7 @@ class MainActivity : AppCompatActivity() {
 
         tvManageUserInfo.setOnClickListener {
             popupWindow.dismiss()
-            Timber.d("## [팝업] 회원 정보 관리 클릭")
+            Timber.d("## [팝업] 회원 정보 클릭")
             navigateTo<UserInfoActivity> {}
         }
 

--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import com.whiplash.presentation.dialog.LogoutPopup
+import com.whiplash.presentation.dialog.WithdrawalPopup
 import com.whiplash.presentation.login.KakaoLoginManager
 import com.whiplash.presentation.util.WhiplashToast
 import kotlinx.coroutines.launch
@@ -31,6 +32,9 @@ class UserInfoActivity : AppCompatActivity() {
 
     @Inject
     lateinit var logoutPopup: LogoutPopup
+
+    @Inject
+    lateinit var withdrawalPopup: WithdrawalPopup
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -131,7 +135,11 @@ class UserInfoActivity : AppCompatActivity() {
                 showAppVersion(false)
                 showRightArrow(true)
                 setOnItemClickListener {
-                    Timber.d("## [회원정보] 회원탈퇴 클릭")
+                    withdrawalPopup.show(
+                        withdrawalClickListener = {
+                            //
+                        }
+                    )
                 }
             }
         }

--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
@@ -17,6 +17,7 @@ import com.whiplash.presentation.databinding.ActivityUserInfoBinding
 import dagger.hilt.android.AndroidEntryPoint
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
+import com.whiplash.presentation.dialog.LogoutPopup
 import com.whiplash.presentation.login.KakaoLoginManager
 import com.whiplash.presentation.util.WhiplashToast
 import kotlinx.coroutines.launch
@@ -29,7 +30,7 @@ class UserInfoActivity : AppCompatActivity() {
     private lateinit var binding: ActivityUserInfoBinding
 
     @Inject
-    lateinit var kakaoLoginManager: KakaoLoginManager
+    lateinit var logoutPopup: LogoutPopup
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -115,9 +116,11 @@ class UserInfoActivity : AppCompatActivity() {
                 showRightArrow(true)
                 setOnItemClickListener {
                     Timber.d("## [회원정보] 로그아웃 클릭")
-                    lifecycleScope.launch {
-                        kakaoLoginManager.signOut()
-                    }
+                    logoutPopup.show(
+                        logoutClickListener = {
+                            //
+                        }
+                    )
                 }
             }
 

--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
@@ -66,8 +66,8 @@ class UserInfoActivity : AppCompatActivity() {
                 showAppVersion(false)
                 showRightArrow(true)
                 setOnItemClickListener {
-                    openWebPage("https://m.naver.com")
                     Timber.d("## [회원정보] 이용약관 클릭")
+                    openWebPage("https://nonstop-alibi-f82.notion.site/2431862b9eb28060b16ec47a60fcef22?source=copy_link")
                 }
             }
 
@@ -79,7 +79,7 @@ class UserInfoActivity : AppCompatActivity() {
                 showRightArrow(true)
                 setOnItemClickListener {
                     Timber.d("## [회원정보] 개인정보처리방침 클릭")
-                    openWebPage("https://m.naver.com")
+                    openWebPage("https://nonstop-alibi-f82.notion.site/2431862b9eb2800b95cdcf5daea2e83e?source=copy_link")
                 }
             }
 

--- a/presentation/src/main/res/layout/layout_logout_popup.xml
+++ b/presentation/src/main/res/layout/layout_logout_popup.xml
@@ -17,26 +17,26 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
-            android:id="@+id/tvDisableAlarmTitle"
+            android:id="@+id/tvLogoutPopupTitle"
             style="@style/subtitle6_b_14"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"
             android:minHeight="22dp"
-            android:text="@string/disable_popup_title"
+            android:text="@string/logout_popup_title"
             android:textColor="@color/white"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <ImageView
-            android:id="@+id/ivDisableAlarmDismiss"
+            android:id="@+id/ivLogoutPopupDismiss"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@drawable/ic_dismiss_black_22"
-            app:layout_constraintBottom_toBottomOf="@+id/tvDisableAlarmTitle"
+            app:layout_constraintBottom_toBottomOf="@+id/tvLogoutPopupTitle"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/tvDisableAlarmTitle" />
+            app:layout_constraintTop_toTopOf="@+id/tvLogoutPopupTitle" />
 
         <TextView
             android:id="@+id/tvDisableAlarmContent"
@@ -45,86 +45,42 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="32dp"
             android:gravity="center"
-            android:text="@string/disable_popup_content"
+            android:text="@string/logout_popup_content"
             android:textColor="@color/white"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tvDisableAlarmTitle" />
-
-        <!-- 알람 끄기 횟수를 모두 쓴 경우에만 표시 -->
-        <TextView
-            android:id="@+id/tvDisableAlarmSubContent"
-            style="@style/body2_m_14"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:gravity="center"
-            android:text="@string/cannot_disable_alarm"
-            android:textColor="@color/grey_300"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tvDisableAlarmContent"
-            tools:visibility="visible" />
-        <!-- 알람 끄기 횟수를 모두 쓴 경우에만 표시 -->
-
-        <LinearLayout
-            android:id="@+id/llRemainDisableAlarmCount"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:background="@drawable/bg_bordered_container_4_radius"
-            android:orientation="horizontal"
-            android:paddingHorizontal="10dp"
-            android:paddingVertical="4dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tvDisableAlarmSubContent">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/disable_alarm_remain_count"
-                android:textColor="@color/grey_300" />
-
-            <TextView
-                android:id="@+id/tvRemainDisableAlarmCount"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:textColor="@color/lemon_400"
-                tools:text="2회" />
-
-        </LinearLayout>
+            app:layout_constraintTop_toBottomOf="@+id/tvLogoutPopupTitle" />
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginVertical="24dp"
+            android:layout_marginTop="24dp"
             android:orientation="horizontal"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/llRemainDisableAlarmCount">
+            app:layout_constraintTop_toBottomOf="@+id/tvDisableAlarmContent">
 
             <com.whiplash.presentation.component.button.WhiplashCommonButton
-                android:id="@+id/btnCancelDisable"
+                android:id="@+id/btnCancelLogout"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="4dp"
                 android:layout_weight="1"
+                app:borderColor="@color/grey_700"
+                app:borderWidth="@dimen/dp_1"
                 app:buttonBackgroundColor="@color/grey_800"
                 app:buttonText="@string/cancel_string"
                 app:buttonTextColor="@color/white" />
 
             <com.whiplash.presentation.component.button.WhiplashCommonButton
-                android:id="@+id/btnAlarmDisable"
+                android:id="@+id/btnLogout"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:layout_weight="1"
                 app:buttonBackgroundColor="@color/white"
-                app:buttonText="@string/home_turn_off_alarm"
+                app:buttonText="@string/logout_popup_title"
                 app:buttonTextColor="@color/grey_900" />
 
         </LinearLayout>

--- a/presentation/src/main/res/layout/layout_withdrawal_popup.xml
+++ b/presentation/src/main/res/layout/layout_withdrawal_popup.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_popup_border_16_radius"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="24dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tvWithdrawalPopupTitle"
+            style="@style/subtitle6_b_14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:minHeight="22dp"
+            android:text="@string/withdrawal_string"
+            android:textColor="@color/white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/ivWithdrawalPopupDismiss"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_dismiss_black_22"
+            app:layout_constraintBottom_toBottomOf="@+id/tvWithdrawalPopupTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/tvWithdrawalPopupTitle" />
+
+        <TextView
+            android:id="@+id/tvWithdrawalPopupContent"
+            style="@style/subtitle5_b_16"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:gravity="center"
+            android:text="@string/withdrawal_popup_content"
+            android:textColor="@color/white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tvWithdrawalPopupTitle" />
+
+        <TextView
+            android:id="@+id/tvWithdrawalPopupSubContent"
+            style="@style/body2_m_14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:gravity="center"
+            android:text="@string/withdrawal_popup_sub_content"
+            android:textColor="@color/grey_300"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tvWithdrawalPopupContent" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tvWithdrawalPopupSubContent">
+
+            <com.whiplash.presentation.component.button.WhiplashCommonButton
+                android:id="@+id/btnCancelWithdrawal"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="4dp"
+                android:layout_weight="1"
+                app:borderColor="@color/grey_700"
+                app:borderWidth="@dimen/dp_1"
+                app:buttonBackgroundColor="@color/grey_800"
+                app:buttonText="@string/cancel_string"
+                app:buttonTextColor="@color/white" />
+
+            <com.whiplash.presentation.component.button.WhiplashCommonButton
+                android:id="@+id/btnWithdrawal"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_weight="1"
+                app:buttonBackgroundColor="@color/white"
+                app:buttonText="@string/withdrawal_popup_ok_button"
+                app:buttonTextColor="@color/grey_900" />
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/values/attrs.xml
+++ b/presentation/src/main/res/values/attrs.xml
@@ -5,6 +5,8 @@
         <attr name="buttonBackgroundColor" format="color|reference" />
         <attr name="buttonText" format="string" />
         <attr name="buttonTextColor" format="color|reference" />
+        <attr name="borderColor" format="color|reference" />
+        <attr name="borderWidth" format="dimension" />
     </declare-styleable>
 
     <!-- 공통 editText -->

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -56,6 +56,12 @@
     <string name="disable_alarm_remain_count">알림끄기 남은 횟수</string>
     <string name="cannot_disable_alarm">이제 알람을 끌 수 없어요.\n지정한 장소로 이동해 알람 끄기를 도전하세요.</string>
 
+    <!-- 로그아웃 팝업 -->
+    <string name="logout_popup_title">로그아웃</string>
+    <string name="logout_popup_content">정말 로그아웃하시겠어요?</string>
+
+    <!-- 회원탈퇴 팝업 -->
+
     <!-- 알람 설정 화면 -->
     <string name="create_alarm_header">알람 설정</string>
     <string name="create_alarm">저장하기</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -61,6 +61,9 @@
     <string name="logout_popup_content">정말 로그아웃하시겠어요?</string>
 
     <!-- 회원탈퇴 팝업 -->
+    <string name="withdrawal_popup_content">정말 탈퇴 하시겠어요?</string>
+    <string name="withdrawal_popup_sub_content">탈퇴 시 기록을 되돌릴 수 없어요</string>
+    <string name="withdrawal_popup_ok_button">탈퇴하기</string>
 
     <!-- 알람 설정 화면 -->
     <string name="create_alarm_header">알람 설정</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="complete_string">완료</string>
     <string name="disable_alarm">알람 끄기</string>
     <string name="remove_alarm">알람 삭제</string>
-    <string name="manage_user_info">회원 정보 관리</string>
+    <string name="manage_user_info">회원 정보</string>
 
     <string name="time_am">오전</string>
     <string name="time_pm">오후</string>

--- a/presentation/src/main/res/xml/network_security_config.xml
+++ b/presentation/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="false">3.34.221.212</domain>
-    </domain-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system"/>
+        </trust-anchors>
+    </base-config>
 </network-security-config>


### PR DESCRIPTION
## 📝 변경 사항
- 로그아웃 팝업 추가
- 회원탈퇴 팝업 추가
- 매니페스트 권한 수정
- 공통 버튼에 테두리색, 두께 설정할 수 있도록 attr 추가

팝업 하나로 만들 수 있지만 합쳤을 때 좋은 이름이 떠오르지 않아서 2개로 나눠 만듦

## 🎯 작업 유형
- [x] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일 변경 (style)
- [ ] 문서 변경 (docs)
- [ ] 프로젝트 설정 변경 (chore)
- [ ] 기타

## 📱 스크린샷 (UI 변경 시)
<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/89b8fa94-65d4-4d01-a5f6-97ab18b36a1b" />
<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/6e4a13d2-5c26-4d09-96a1-821bf0de0f38" />
