### PR TITLE
feat: 회원 탈퇴 기능 추가

### DIFF
--- a/data/src/main/kotlin/com/whiplash/data/di/UseCaseModule.kt
+++ b/data/src/main/kotlin/com/whiplash/data/di/UseCaseModule.kt
@@ -14,6 +14,7 @@ import com.whiplash.domain.usecase.auth.ReissueTokenUseCase
 import com.whiplash.domain.usecase.auth.SocialLoginUseCase
 import com.whiplash.domain.usecase.auth.SocialLogoutUseCase
 import com.whiplash.domain.usecase.member.ChangeTermsStateUseCase
+import com.whiplash.domain.usecase.member.WithdrawUseCase
 import com.whiplash.domain.usecase.onboarding.GetOnboardingStatusUseCase
 import com.whiplash.domain.usecase.onboarding.SetOnboardingCompletedUseCase
 import com.whiplash.domain.usecase.place.GetPlaceDetailUseCase
@@ -57,6 +58,11 @@ object UseCaseModule {
     @Singleton
     fun provideSocialLogoutUseCase(repository: AuthRepository): SocialLogoutUseCase =
         SocialLogoutUseCase(repository)
+
+    @Provides
+    @Singleton
+    fun provideWithdrawUseCase(repository: MemberRepository): WithdrawUseCase =
+        WithdrawUseCase(repository)
 
     @Provides
     @Singleton

--- a/data/src/main/kotlin/com/whiplash/data/repository/member/MemberRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/whiplash/data/repository/member/MemberRepositoryImpl.kt
@@ -12,6 +12,12 @@ class MemberRepositoryImpl @Inject constructor(
     private val service: MemberService,
     private val mapper: MemberMapper,
 ): MemberRepository {
+    override suspend fun withdraw(): Flow<Result<Unit>> =
+        safeApiCallWithTransform(
+            apiCall = { service.withdraw() },
+            transform = {}
+        )
+
     override suspend fun changeTermsState(request: ChangeTermsStateEntity): Flow<Result<Unit>> =
         safeApiCallWithTransform(
             apiCall = { service.changeTermsState(mapper.toNetworkRequest(request)) },

--- a/domain/src/main/java/com/whiplash/domain/repository/member/MemberRepository.kt
+++ b/domain/src/main/java/com/whiplash/domain/repository/member/MemberRepository.kt
@@ -4,5 +4,6 @@ import com.whiplash.domain.entity.auth.request.ChangeTermsStateEntity
 import kotlinx.coroutines.flow.Flow
 
 interface MemberRepository {
+    suspend fun withdraw(): Flow<Result<Unit>>
     suspend fun changeTermsState(request: ChangeTermsStateEntity): Flow<Result<Unit>>
 }

--- a/domain/src/main/java/com/whiplash/domain/usecase/member/WithdrawUseCase.kt
+++ b/domain/src/main/java/com/whiplash/domain/usecase/member/WithdrawUseCase.kt
@@ -1,0 +1,10 @@
+package com.whiplash.domain.usecase.member
+
+import com.whiplash.domain.repository.member.MemberRepository
+import kotlinx.coroutines.flow.Flow
+
+class WithdrawUseCase(
+    private val repository: MemberRepository
+) {
+    suspend operator fun invoke(): Flow<Result<Unit>> = repository.withdraw()
+}

--- a/network/src/main/kotlin/com/whiplash/network/api/MemberService.kt
+++ b/network/src/main/kotlin/com/whiplash/network/api/MemberService.kt
@@ -4,9 +4,18 @@ import com.whiplash.network.dto.request.RequestChangeTermsState
 import com.whiplash.network.dto.response.BaseResponse
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.PUT
 
 interface MemberService {
+
+    /**
+     * 회원 탈퇴
+     *
+     * 회원 정보, 회원 관련 알람들을 hard delete
+     */
+    @DELETE("members")
+    suspend fun withdraw(): Response<BaseResponse<Unit>>
 
     /**
      * 회원 약관 동의 정보 변경

--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -234,6 +235,23 @@ class UserInfoActivity : AppCompatActivity() {
     private fun openWebPage(url: String) {
         val intent = Intent(Intent.ACTION_VIEW, url.toUri())
         startActivity(intent)
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        checkNotificationPermissionStatus()
+    }
+
+    private fun checkNotificationPermissionStatus(): Boolean {
+        val isNotificationEnabled = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+        } else {
+            NotificationManagerCompat.from(this).areNotificationsEnabled()
+        }
+
+        Timber.d("## [회원정보] 푸시 알림 허용 상태 : $isNotificationEnabled")
+        return isNotificationEnabled
     }
 
 }

--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -29,6 +30,8 @@ import javax.inject.Inject
 class UserInfoActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityUserInfoBinding
+
+    private val userInfoViewModel: UserInfoViewModel by viewModels()
 
     @Inject
     lateinit var logoutPopup: LogoutPopup

--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
@@ -18,10 +18,14 @@ import com.whiplash.presentation.R
 import com.whiplash.presentation.databinding.ActivityUserInfoBinding
 import dagger.hilt.android.AndroidEntryPoint
 import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.whiplash.presentation.dialog.LogoutPopup
 import com.whiplash.presentation.dialog.WithdrawalPopup
 import com.whiplash.presentation.login.KakaoLoginManager
+import com.whiplash.presentation.login.LoginActivity
+import com.whiplash.presentation.util.ActivityUtils.navigateTo
 import com.whiplash.presentation.util.WhiplashToast
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -51,12 +55,29 @@ class UserInfoActivity : AppCompatActivity() {
             insets
         }
 
+        observeUserInfoViewModel()
         setupUserInfoViews()
+    }
+
+    private fun observeUserInfoViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                userInfoViewModel.uiState.collect { state ->
+                    // 회원 탈퇴 성공 여부
+                    if (state.isWithdrawCompleted) {
+                        WhiplashToast.showSuccessToast(this@UserInfoActivity, getString(R.string.withdrawal_success_message))
+                        navigateTo<LoginActivity> {
+                            setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun setupUserInfoViews() {
         with(binding) {
-            whUserInfo.setTitle("회원 정보")
+            whUserInfo.setTitle(getString(R.string.manage_user_info))
 
             // 현재 버전
             uivCurrentVersion.apply {

--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
@@ -66,6 +66,7 @@ class UserInfoActivity : AppCompatActivity() {
                     // 회원 탈퇴 성공 여부
                     if (state.isWithdrawCompleted) {
                         WhiplashToast.showSuccessToast(this@UserInfoActivity, getString(R.string.withdrawal_success_message))
+                        userInfoViewModel.clearWithdrawCompleted()
                         navigateTo<LoginActivity> {
                             setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
                         }

--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoActivity.kt
@@ -141,7 +141,7 @@ class UserInfoActivity : AppCompatActivity() {
                 setOnItemClickListener {
                     withdrawalPopup.show(
                         withdrawalClickListener = {
-                            //
+                            userInfoViewModel.withdraw()
                         }
                     )
                 }

--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoViewModel.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoViewModel.kt
@@ -1,0 +1,111 @@
+package com.whiplash.presentation.user_info
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.whiplash.domain.entity.auth.request.ChangeTermsStateEntity
+import com.whiplash.domain.usecase.member.ChangeTermsStateUseCase
+import com.whiplash.domain.usecase.member.WithdrawUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class UserInfoViewModel @Inject constructor(
+    private val changeTermsStateUseCase: ChangeTermsStateUseCase,
+    private val withdrawUseCase: WithdrawUseCase,
+): ViewModel() {
+
+    data class UserInfoUiState(
+        val isLoading: Boolean = false,
+        val errorMessage: String? = null,
+
+        // 회원 탈퇴 성공 여부
+        val isWithdrawCompleted: Boolean = false,
+
+        // 약관 동의 상태 변경 성공 여부
+        val isTermsStateChanged: Boolean = false,
+    )
+
+    private val _uiState = MutableStateFlow(UserInfoUiState())
+    val uiState: StateFlow<UserInfoUiState> = _uiState.asStateFlow()
+
+    // 회원 탈퇴
+    fun withdraw() = viewModelScope.launch {
+        _uiState.update { it.copy(isLoading = true) }
+
+        try {
+            withdrawUseCase.invoke().collect { result ->
+                result.onSuccess {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            isWithdrawCompleted = true
+                        )
+                    }
+                }.onFailure { e ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = e.message
+                        )
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    errorMessage = e.message
+                )
+            }
+        }
+    }
+
+    // 약관 동의 상태 변경
+    fun changeTermsState(
+        privacyPolicy: Boolean,
+        pushNotificationPolicy: Boolean
+    ) = viewModelScope.launch {
+        _uiState.update { it.copy(isLoading = true) }
+
+        try {
+            val request = ChangeTermsStateEntity(
+                privacyPolicy = privacyPolicy,
+                pushNotificationPolicy = pushNotificationPolicy
+            )
+
+            changeTermsStateUseCase.invoke(request).collect { result ->
+                result.onSuccess {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            isTermsStateChanged = true
+                        )
+                    }
+                }.onFailure { e ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = e.message
+                        )
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    errorMessage = e.message
+                )
+            }
+        }
+    }
+
+    fun clearErrorMessage() {
+        _uiState.update { it.copy(errorMessage = null) }
+    }
+}

--- a/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoViewModel.kt
+++ b/presentation/src/main/java/com/whiplash/presentation/user_info/UserInfoViewModel.kt
@@ -65,6 +65,8 @@ class UserInfoViewModel @Inject constructor(
         }
     }
 
+    fun clearWithdrawCompleted() = _uiState.update { it.copy(isWithdrawCompleted = false) }
+
     // 약관 동의 상태 변경
     fun changeTermsState(
         privacyPolicy: Boolean,

--- a/presentation/src/main/res/layout/activity_user_info.xml
+++ b/presentation/src/main/res/layout/activity_user_info.xml
@@ -62,7 +62,7 @@
         android:layout_marginTop="20dp"
         android:layout_height="wrap_content"/>
 
-    <!-- 정보동의 설정 -->
+    <!-- 동의여부 설정 -->
     <com.whiplash.presentation.component.view.UserInfoView
         android:id="@+id/uivSettingAgreements"
         android:layout_width="match_parent"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="inquiry_string">문의하기</string>
     <string name="logout_string">로그아웃하기</string>
     <string name="withdrawal_string">회원탈퇴</string>
+    <string name="withdrawal_success_message">회원 탈퇴가 완료되었습니다</string>
 
     <!-- 회원 정보 화면 > XML -->
     <string name="version_info_title">버전 정보</string>


### PR DESCRIPTION
## 📝 변경 사항
- 회원탈퇴 api 구현, 적용
- 회원 정보 화면에서 회원탈퇴 팝업 표시 > 탈퇴하기 클릭 시 회원탈퇴 api 호출되게 수정

## 🎯 작업 유형
- [x] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 스타일 변경 (style)
- [ ] 문서 변경 (docs)
- [ ] 프로젝트 설정 변경 (chore)
- [ ] 기타